### PR TITLE
Feature path updated in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
     }
   ],
   "features": {
-    "ghcr.io/devcontainers-contrib/features/act-asdf:2": {},
+    "ghcr.io/devcontainers-extra/features/act-asdf:2": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "dockerDashComposeVersion": "v2"
     },
@@ -35,7 +35,7 @@
       "configureZshAsDefaultShell": true,
       "username": "root"
     },
-    "ghcr.io/devcontainers-contrib/features/starship:1": {},
+    "ghcr.io/devcontainers-extra/features/starship:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
       "packages": "exa,bat,curl,fontconfig",
       "upgradePackages": true


### PR DESCRIPTION
This pull request updates the `.devcontainer/devcontainer.json` file to replace feature sources from `devcontainers-contrib` with `devcontainers-extra`. This change ensures compatibility and aligns with the updated feature repository.

Key changes:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L30-R38): Updated the source for the `act-asdf` feature from `ghcr.io/devcontainers-contrib/features/act-asdf:2` to `ghcr.io/devcontainers-extra/features/act-asdf:2`.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L30-R38): Updated the source for the `starship` feature from `ghcr.io/devcontainers-contrib/features/starship:1` to `ghcr.io/devcontainers-extra/features/starship:1`.