### PR TITLE
Update air install ref

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -140,7 +140,7 @@
   },
   "postCreateCommand": {
     "install-zsh-plugins": "git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting && git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions",
-    "api-reload": "go install github.com/cosmtrek/air@latest",
+    "api-reload": "go install github.com/air-verse/air@latest",
     "taskfile": "go install github.com/go-task/task/v3/cmd/task@latest",
     "modules": "go mod download"
   },


### PR DESCRIPTION
This pull request updates the `postCreateCommand` section in the `.devcontainer/devcontainer.json` file to use a different repository for the `api-reload` tool.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L143-R143): Changed the `api-reload` command to install the `air` tool from the `github.com/air-verse` repository instead of `github.com/cosmtrek`.