### PR TITLE
Fix container version and install go packages packages on docker build.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
 FROM mcr.microsoft.com/vscode/devcontainers/go:1.24-bullseye
 
 # Install additional packages
-RUN go install github.com/air-verse/air@latest
-RUN go install github.com/go-task/task/v3/cmd/task@latest
+RUN go install github.com/air-verse/air@latest && go install github.com/go-task/task/v3/cmd/task@latest

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/vscode/devcontainers/go:1.24-bullseye
 
 # Install additional packages
-RUN go install github.com/air-verse/air@latest && go install github.com/go-task/task/v3/cmd/task@latest
+RUN go install github.com/air-verse/air@v1.62.0 && go install github.com/go-task/task/v3/cmd/task@v3.44.0

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-ARG GO_VERSION=1-1-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/go:1.24-bullseye
 
-ARG VARIANT=1-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/go:${GO_VERSION}
+# Install additional packages
+RUN go install github.com/air-verse/air@latest
+RUN go install github.com/go-task/task/v3/cmd/task@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -132,16 +132,9 @@
       }
     }
   },
-  "portsAttributes": {
-    "9000": {
-      "label": "Hello Remote World",
-      "onAutoForward": "notify"
-    }
-  },
+  "portsAttributes": {},
   "postCreateCommand": {
     "install-zsh-plugins": "git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting && git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions",
-    "api-reload": "go install github.com/cosmtrek/air@latest",
-    "taskfile": "go install github.com/go-task/task/v3/cmd/task@latest",
     "modules": "go mod download"
   },
   "remoteUser": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -132,7 +132,6 @@
       }
     }
   },
-  "portsAttributes": {},
   "postCreateCommand": {
     "install-zsh-plugins": "git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting && git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions",
     "modules": "go mod download"


### PR DESCRIPTION
This pull request updates the development container configuration by switching to a newer Go image, installing additional tools, and simplifying the `devcontainer.json` file. The most important changes include updating the Dockerfile to use a specific Go image version and removing redundant configurations in `devcontainer.json`.

### Updates to the development container:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-R5): Updated the base image to `mcr.microsoft.com/vscode/devcontainers/go:1.24-bullseye` and added installation commands for the `air` and `task` tools.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L135-L144): Removed the `portsAttributes` configuration and redundant tool installation commands in the `postCreateCommand`. The installation of `air` and `task` was moved to the Dockerfile for better organization.